### PR TITLE
Add code to generate JSON schemas, to pass to ETL as needed

### DIFF
--- a/cumulus_library_glioma/llm/pydantic_schema/annotation.py
+++ b/cumulus_library_glioma/llm/pydantic_schema/annotation.py
@@ -1,34 +1,46 @@
+import json
+import os
+
 from pydantic import BaseModel, Field
-from .pathology import TopographyMention, MorphologyMention, GradeMention, BehaviorMention
-from .genes import TargetGeneticTestMention, VariantMention
-from .drugs import CancerMedicationMention
-from .surgery import SurgeryMention
+from cumulus_library_glioma.llm.pydantic_schema.pathology import (
+    TopographyMention,
+    MorphologyMention,
+    GradeMention,
+    BehaviorMention,
+)
+from cumulus_library_glioma.llm.pydantic_schema.genes import (
+    TargetGeneticTestMention,
+    VariantMention,
+)
+from cumulus_library_glioma.llm.pydantic_schema.drugs import CancerMedicationMention
+from cumulus_library_glioma.llm.pydantic_schema.surgery import SurgeryMention
+
 
 class GliomaCaseAnnotation(BaseModel):
     """
     SCHEMA root of Glioma Case Annotation
     """
+
     topography_mention: TopographyMention
     morphology_mention: MorphologyMention
     behavior_mention: BehaviorMention
     grade_mention: GradeMention
     target_genetic_test_mention: list[TargetGeneticTestMention] = Field(
-        default_factory=list,
-        description="All mentions of Target Genetic Tests."
+        default_factory=list, description="All mentions of Target Genetic Tests."
     )
     variant_mention: list[VariantMention] = Field(
-        default_factory=list,
-        description="All mentions of Genetic Variants."
+        default_factory=list, description="All mentions of Genetic Variants."
     )
     cancer_medication_mention: list[CancerMedicationMention] = Field(
-        default_factory=list,
-        description="All mentions of Cancer Medications."
+        default_factory=list, description="All mentions of Cancer Medications."
     )
     surgery_mention: list[SurgeryMention] = Field(
-        default_factory=list,
-        description="All mentions of Cancer related surgeries."
+        default_factory=list, description="All mentions of Cancer related surgeries."
     )
 
 
+if __name__ == "__main__":
+    basedir = os.path.dirname(__file__)
 
-
+    with open(f"{basedir}/case.json", "w", encoding="utf8") as f:
+        json.dump(GliomaCaseAnnotation.model_json_schema(), f, indent=2)

--- a/cumulus_library_glioma/llm/pydantic_schema/genes.py
+++ b/cumulus_library_glioma/llm/pydantic_schema/genes.py
@@ -79,6 +79,6 @@ class VariantMention(SpanAugmentedMention):
     )
 
     hgvs_variant:str = Field(
-        str,
+        None,
         description="Human Genome Variation Society (HGVS) variant"
     )


### PR DESCRIPTION
This way, the ETL doesn't need its own copy of the pydantic models, just the JSON schema. Eventually that will move over too, but baby steps.