### PR TITLE
:zap: Optimize create table dx comorbidity sql

### DIFF
--- a/cumulus_library_glioma/athena/glioma__cohort_casedef_dx_comorbidity.sql
+++ b/cumulus_library_glioma/athena/glioma__cohort_casedef_dx_comorbidity.sql
@@ -1,31 +1,33 @@
-create  table glioma__cohort_casedef_dx_comorbidity as
-WITH
-casedef as
-(
-    select distinct
-            days_since,
-            ordinal_since,
-            pre,
-            peri,
-            peri_post,
-            post,
-            dx_system,
-            coalesce(dx_code, 'NO_CODE')        as dx_code,
-            coalesce(dx_display, 'NO_DISPLAY')  as dx_display,
-            subject_ref,
-            encounter_ref
-    from    glioma__cohort_casedef
+create table glioma__cohort_casedef_dx_comorbidity as
+with excluded_codes as (
+    select distinct code, system 
+    from glioma__valueset_casedef
+),
+filtered_dx as (
+    select 
+        dx.subject_ref,
+        dx.encounter_ref,
+        coalesce(dx.dx_code, 'no_code') as dx_code,
+        coalesce(dx.dx_display, 'no_display') as dx_display,
+        dx.dx_system
+    from glioma__cohort_study_population_dx as dx
+    left join excluded_codes ev 
+      on dx.dx_code = ev.code 
+      and dx.dx_system = ev.system
+    where ev.code is null 
+),
+casedef_unique as (
+    select distinct 
+        subject_ref, days_since, ordinal_since, pre, peri, peri_post, post
+    from glioma__cohort_casedef
 )
-select  distinct
-        casedef.days_since,
-        casedef.ordinal_since,
-        casedef.pre,
-        casedef.peri,
-        casedef.peri_post,
-        casedef.post,
-        dx.*
-from    casedef,
-        glioma__cohort_study_population_dx as dx
-where   casedef.subject_ref = dx.subject_ref
-and     (dx.dx_code, dx.dx_system) not in
-        (select distinct code, system from glioma__valueset_casedef)
+select 
+    c.days_since,
+    c.ordinal_since,
+    c.pre,
+    c.peri,
+    c.peri_post,
+    c.post,
+    f.*
+from filtered_dx f
+join casedef_unique c on f.subject_ref = c.subject_ref;


### PR DESCRIPTION
Optimize create table query by:
- First filter dx codes to ones that do not exist in glioma value set
- Include only unique patient-encounter rows for the patient, dx join