### PR TITLE
LLM: Result parsing should point at sub-task tables; adds CLAUDE specific versions of LLM casedef construction

### DIFF
--- a/cumulus_library_glioma/athena/glioma__llm_drug_CLAUDE.sql
+++ b/cumulus_library_glioma/athena/glioma__llm_drug_CLAUDE.sql
@@ -1,0 +1,21 @@
+create or replace view glioma__llm_drug as
+select      distinct
+            coalesce(drug.has_mention, False)           as has_mention,
+            coalesce(drug.rx_class, 'NOT_MENTIONED')    as rx_class,
+            coalesce(drug.status, 'NOT_MENTIONED')      as status,
+            coalesce(drug.category, 'NOT_MENTIONED')    as category,
+            coalesce(drug.route, 'NOT_MENTIONED')       as route,
+            coalesce(drug.phase, 'NOT_MENTIONED')       as phase,
+            coalesce(drug.frequency, 'NOT_MENTIONED')   as frequency,
+            drug.start_date,
+            drug.end_date,
+            drug.quantity_unit,
+            drug.quantity_value,
+            drug.expected_supply_days,
+            drug.number_of_repeats_allowed,
+            nlp.note_ref,
+            nlp.encounter_ref,
+            nlp.subject_ref
+from        glioma__nlp_document_type_claude_sonnet45 as nlp
+LEFT JOIN   UNNEST(nlp.result.cancer_medication_mention) AS t(drug)
+ON TRUE;

--- a/cumulus_library_glioma/athena/glioma__llm_dx_CLAUDE.sql
+++ b/cumulus_library_glioma/athena/glioma__llm_dx_CLAUDE.sql
@@ -1,0 +1,144 @@
+create or replace view glioma__llm_dx as
+WITH
+raw as
+(
+    select      distinct
+                result.grade_mention.has_mention        as grade_has_mention,
+                result.grade_mention.code               as grade_code,
+                result.grade_mention.display            as grade_display,
+
+                result.topography_mention.has_mention   as topography_has_mention,
+
+                case    when UPPER(result.topography_mention.display) like 'C0%'
+                        then NULL else result.topography_mention.display end as topography_display,
+
+                case    when UPPER(result.topography_mention.code) like 'C0%'
+                        then NULL else result.topography_mention.code end as topography_code,
+
+                result.morphology_mention.has_mention   as morphology_has_mention,
+
+                case    when UPPER(result.morphology_mention.display) like '0%%'
+                        then NULL else result.morphology_mention.display end as morphology_display,
+
+                case    when UPPER(result.morphology_mention.code) like '0%%'
+                        then NULL else result.morphology_mention.code end as morphology_code,
+
+                element_at(split(result.morphology_mention.code, '/'), 1) AS morphology_histology,
+                element_at(split(result.morphology_mention.code, '/'), 2) AS morphology_behavior,
+
+                result.behavior_mention.has_mention     as behavior_has_mention,
+                result.behavior_mention.code            as behavior_code,
+                result.behavior_mention.display         as behavior_display,
+
+                note_ref,
+                encounter_ref,
+                subject_ref
+    from        glioma__nlp_document_type_claude_sonnet45
+),
+clean as
+(
+    select      distinct
+                raw.grade_has_mention,
+                nullif(trim(raw.grade_code), '')            as grade_code,
+                nullif(trim(raw.grade_display), '')         as grade_display,
+
+                raw.topography_has_mention,
+                nullif(trim(raw.topography_code), '')       as topography_code,
+                nullif(trim(raw.topography_display), '')    as topography_display,
+                
+                raw.morphology_has_mention,
+                nullif(trim(raw.morphology_code), '')       as morphology_code,
+                nullif(trim(raw.morphology_display), '')    as morphology_display,
+                
+                nullif(trim(raw.morphology_histology), '')  as morphology_histology,
+                nullif(trim(raw.morphology_behavior), '')   as morphology_behavior,
+                
+                raw.behavior_has_mention,                 
+                nullif(trim(raw.behavior_code), '')         as behavior_code,
+                nullif(trim(raw.behavior_display), '')      as behavior_display,
+
+                nci_grade.display           as grade_display_nci,
+                casedef.display             as topography_display_casdef,
+                nci.morphology_display      as morphology_display_nci,
+                nci_behave.display          as behavior_display_nci,
+                nci.category_display        as category_display_nci,
+
+                note_ref,
+                encounter_ref,
+                subject_ref
+    from        raw
+    left join   glioma__valueset_casedef    as casedef   on raw.topography_code = casedef.code
+    left join   glioma__nci_site_histology  as nci       on raw.morphology_code = nci.morphology_code
+    left join   glioma__nci_grade           as nci_grade on raw.grade_code = nci_grade.code
+    left join   glioma__nci_behavior        as nci_behave on raw.behavior_code = nci_behave.code
+),
+best as
+(
+    select      distinct
+                -- Grade
+                clean.grade_has_mention,
+                coalesce(
+                    clean.grade_display_nci,
+                    concat(clean.grade_display, ' (?)'),
+                    concat(cast(clean.grade_code as varchar), ' (#)'),
+                    'NONE') as grade_display_best,
+
+                clean.grade_display_nci,
+                clean.grade_display,
+                clean.grade_code,
+
+                -- Topography
+                clean.topography_has_mention,
+                coalesce(
+                    clean.topography_display_casdef,
+                    concat(clean.topography_display, ' (?)'),
+                    concat(cast(clean.topography_code as varchar), ' (#)'),
+                    'NONE') as topography_display_best,
+
+                clean.topography_display_casdef,
+                clean.topography_code,
+
+                -- Morphology
+                clean.morphology_has_mention,
+                coalesce(
+                    clean.morphology_display_nci,
+                    concat(clean.morphology_display, ' (?)'),
+                    concat(cast(clean.morphology_code as varchar), ' (#)'),
+                    'NONE') as morphology_display_best,
+
+                clean.morphology_display_nci,
+                clean.morphology_display,
+                clean.morphology_code,
+                clean.morphology_histology,
+                clean.morphology_behavior,
+
+                -- Behavior
+                clean.behavior_has_mention,
+
+                coalesce(
+                    clean.behavior_display_nci,
+                    concat(clean.behavior_display, ' (?)'),
+                    concat(cast(clean.behavior_code as varchar), ' (#)'),
+                    'NONE') as behavior_display_best,
+
+                clean.behavior_display_nci,
+                clean.behavior_display,
+                clean.behavior_code,
+
+                -- Category (Histological)
+                coalesce(
+                    clean.category_display_nci,
+                    nci.category_display,
+                    'NONE') as category_display_best,
+
+                clean.category_display_nci,
+                nci.category_display as category_display,
+
+                -- FHIR References
+                note_ref,
+                encounter_ref,
+                subject_ref
+    from        clean
+    left join   glioma__nci_site_histology  as nci    on clean.morphology_histology = nci.histology_code
+)
+select * from best ;

--- a/cumulus_library_glioma/athena/glioma__llm_gene_CLAUDE.sql
+++ b/cumulus_library_glioma/athena/glioma__llm_gene_CLAUDE.sql
@@ -1,0 +1,40 @@
+-- ############################################################################
+-- Clinical decision making << Clinical Gene Tests >>
+-- See also glioma__llm_variant
+create or replace view glioma__llm_gene as
+select      distinct
+            coalesce(genetics.has_mention, False)     as has_mention,
+            case genetics.braf_altered
+                when True   then 'positive'
+                when False  then 'negative'
+                else 'NOT_MENTIONED' end as braf_altered,
+            case genetics.braf_v600e
+                when True   then 'positive'
+                when False  then 'negative'
+                else 'NOT_MENTIONED' end as braf_v600e,
+            case genetics.braf_fusion
+                when True   then 'positive'
+                when False  then 'negative'
+                else 'NOT_MENTIONED' end as braf_fusion,
+            case genetics.idh_mutant
+                when True   then 'positive'
+                when False  then 'negative'
+                else 'NOT_MENTIONED' end as idh_mutant,
+            case genetics.h3k27m_mutant
+                when True   then 'positive'
+                when False  then 'negative'
+                else 'NOT_MENTIONED' end as h3k27m_mutant,
+            case genetics.tp53_altered
+                when True   then 'positive'
+                when False  then 'negative'
+                else 'NOT_MENTIONED' end as tp53_altered,
+            case genetics.cdkn2a_deleted
+                when True   then 'positive'
+                when False  then 'negative'
+                else 'NOT_MENTIONED' end as cdkn2a_deleted,
+            nlp.note_ref,
+            nlp.encounter_ref,
+            nlp.subject_ref
+from        glioma__nlp_document_type_claude_sonnet45 as nlp
+LEFT JOIN   UNNEST(nlp.result.target_genetic_test_mention) AS t(genetics)
+ON TRUE;

--- a/cumulus_library_glioma/athena/glioma__llm_surgery_CLAUDE.sql
+++ b/cumulus_library_glioma/athena/glioma__llm_surgery_CLAUDE.sql
@@ -1,0 +1,15 @@
+create or replace view glioma__llm_surgery as
+select      distinct
+            coalesce(surgery.has_mention, False)                as has_mention,
+            coalesce(surgery.anatomical_site, 'NOT_MENTIONED')  as anatomical_site,
+            coalesce(surgery.surgical_type, 'NOT_MENTIONED')    as surgical_type,
+            coalesce(surgery.approach, 'NOT_MENTIONED')         as approach,
+            coalesce(surgery.extent_of_resection, 'NOT_MENTIONED')  as extent_of_resection,
+            coalesce(surgery.technique_details, 'NOT_MENTIONED')    as technique_details,
+            coalesce(surgery.complications, 'NOT_MENTIONED')        as complications,
+            nlp.note_ref,
+            nlp.encounter_ref,
+            nlp.subject_ref
+from        glioma__nlp_document_type_claude_sonnet45 as nlp
+LEFT JOIN   UNNEST(nlp.result.surgery_mention) AS t(surgery)
+ON TRUE;

--- a/cumulus_library_glioma/athena/glioma__llm_variant_CLAUDE.sql
+++ b/cumulus_library_glioma/athena/glioma__llm_variant_CLAUDE.sql
@@ -1,0 +1,17 @@
+-- ############################################################################
+-- DNA sequenced variants
+-- See also glioma__llm_gene
+
+create or replace view glioma__llm_variant as
+select      distinct
+            coalesce(variant.has_mention, False)                as has_mention,
+            coalesce(variant.hgnc_name, 'NOT_MENTIONED')        as hgnc_name,
+            coalesce(variant.hgvs_variant, 'NOT_MENTIONED')     as hgvs_variant,
+            coalesce(variant.interpretation, 'NOT_MENTIONED')   as interpretation,
+            nlp.note_ref,
+            nlp.encounter_ref,
+            nlp.subject_ref
+from        glioma__nlp_document_type_claude_sonnet45 as nlp
+LEFT JOIN   UNNEST(nlp.result.variant_mention) AS t(variant)
+ON TRUE;
+

--- a/cumulus_library_glioma/athena/glioma__sample_casedef_task_CLAUDE.sql
+++ b/cumulus_library_glioma/athena/glioma__sample_casedef_task_CLAUDE.sql
@@ -6,7 +6,7 @@ mention as (
             src.note_ref,
             src.encounter_ref,
             src.subject_ref
-    from    glioma__nlp_document_type_gpt_oss_120b    AS src,
+    from    glioma__nlp_document_type_claude_sonnet45    AS src,
             UNNEST(src.result.doc_type) AS t1(src_result_mention)
     where   task_version = 2000
     and     src_result_mention IS NOT NULL

--- a/cumulus_library_glioma/manifest_llm_CLAUDE.toml
+++ b/cumulus_library_glioma/manifest_llm_CLAUDE.toml
@@ -1,0 +1,160 @@
+study_prefix = "glioma"
+
+[file_config.file_names]
+# -----------------------------------------------------------------------------
+## Upload CSV/TSV curated files
+"file_upload.toml" = [
+    "file_upload.toml"
+]
+
+## -----------------------------------------------------------------------------
+## Study population
+"inclusion criteria for study population" = [
+    "athena/glioma__include_gender.sql",
+    "athena/glioma__include_age_at_visit.sql",
+    "athena/glioma__include_utilization.sql",
+    "athena/glioma__include_study_period.sql",
+]
+
+"study period" = [
+    "athena/glioma__cohort_study_period.sql",
+]
+
+"study population" = [
+    "athena/glioma__cohort_study_population.sql",
+]
+
+"study population (dx, rx, lab, proc, doc, diag)" = [
+    "athena/glioma__cohort_study_population_dx.sql",
+    "athena/glioma__cohort_study_population_rx.sql",
+    "athena/glioma__cohort_study_population_lab.sql",
+    "athena/glioma__cohort_study_population_doc.sql",
+    "athena/glioma__cohort_study_population_diag.sql",
+    "athena/glioma__cohort_study_population_proc.sql",
+]
+
+## -----------------------------------------------------------------------------
+##  *CASE DEFINITION* pLGG (Pediatric Low Grade Glioma)
+
+"cohort from case definition (valueset_casedef)"= [
+    "athena/glioma__cohort_casedef.sql",
+]
+
+"cohort for case definition aspects (dx, rx, lab, proc)"= [
+    "athena/glioma__cohort_casedef_dx_comorbidity.sql",
+    "athena/glioma__cohort_casedef_rx.sql",
+    "athena/glioma__cohort_casedef_lab.sql",
+    "athena/glioma__cohort_casedef_proc.sql",
+]
+
+"cohort for glioma drug variables (rx)" = [
+    "athena/glioma__cohort_casedef_rx_variable.sql"
+]
+
+"samples for casedef temporality (pre, per, peri_post, post)"= [
+    "athena/glioma__sample_casedef.sql",
+	"athena/glioma__sample_casedef_pre.sql",
+	"athena/glioma__sample_casedef_peri.sql",
+	"athena/glioma__sample_casedef_peri_post.sql",
+	"athena/glioma__sample_casedef_post.sql",
+]
+
+"samples for casedef temporality (limit_note, limit_patient)"= [
+	"athena/glioma__sample_casedef_pre_limit_patient_10.sql",
+	"athena/glioma__sample_casedef_pre_limit_note_50.sql",
+	"athena/glioma__sample_casedef_peri_limit_patient_10.sql",
+	"athena/glioma__sample_casedef_peri_limit_note_50.sql",
+	"athena/glioma__sample_casedef_peri_post_limit_patient_10.sql",
+	"athena/glioma__sample_casedef_peri_post_limit_note_50.sql",
+	"athena/glioma__sample_casedef_post_limit_patient_10.sql",
+	"athena/glioma__sample_casedef_post_limit_note_50.sql",
+]
+
+"cube casedef"= [
+	"athena/glioma__cube_encounter_casedef.sql",
+	"athena/glioma__cube_patient_casedef.sql",
+	"athena/glioma__cube_patient_casedef_dx_comorbidity.sql",
+	"athena/glioma__cube_patient_casedef_rx.sql",
+	"athena/glioma__cube_patient_casedef_rx_variable.sql",
+	"athena/glioma__cube_patient_casedef_proc.sql",
+	"athena/glioma__cube_patient_casedef_lab.sql",
+	"athena/glioma__cube_patient_sample_casedef.sql",
+	"athena/glioma__cube_note_sample_casedef.sql",
+	"athena/glioma__cube_patient_sample_casedef_peri_post.sql",
+	"athena/glioma__cube_note_sample_casedef_peri_post.sql",
+]
+
+"metadata study date and versioning " = [
+    "athena/glioma__meta_date.sql",
+    "athena/glioma__meta_version.sql"
+]
+
+## -----------------------------------------------------------------------------
+##  LLM specific section
+##
+##  Next cumulus-library version will allow submanifests RATHER THAN
+##  `manifest_casedef.toml` being redeclared again as per above. See ticket:
+##  https://github.com/smart-on-fhir/cumulus-library/issues/437
+
+"samples for LLM tasks" = [
+    "athena/glioma__sample_casedef_task_CHOP.sql"
+]
+
+"samples for LLM tasks diagnosis, drug, gene, surgery, progression" = [
+    "athena/glioma__sample_casedef_task_diagnosis.sql",
+    "athena/glioma__sample_casedef_task_drug.sql",
+    "athena/glioma__sample_casedef_task_gene.sql",
+    "athena/glioma__sample_casedef_task_surgery.sql",
+    "athena/glioma__sample_casedef_task_progression.sql",
+]
+
+"glioma LLM (ICDO: grade, topography, morphology, behavior)" = [
+    "athena/glioma__llm_dx_CHOP.sql",
+]
+
+"glioma LLM (surgery, drug, gene, variant)" = [
+    "athena/glioma__llm_surgery_CHOP.sql",
+    "athena/glioma__llm_drug_CHOP.sql",
+    "athena/glioma__llm_gene_CHOP.sql",
+    "athena/glioma__llm_variant_CHOP.sql",
+]
+
+"cube LLM"= [
+    "athena/glioma__cube_patient_llm_dx.sql",
+    "athena/glioma__cube_patient_llm_surgery.sql",
+    "athena/glioma__cube_patient_llm_drug.sql",
+    "athena/glioma__cube_patient_llm_variant.sql",
+    "athena/glioma__cube_patient_llm_gene.sql",
+]
+
+## -----------------------------------------------------------------------------
+## Export to Cumulus aggregator
+
+[export_config]
+
+count_list = [
+    # Case Definition
+	"glioma__cube_encounter_casedef",
+	"glioma__cube_patient_casedef",
+	"glioma__cube_patient_casedef_dx_comorbidity",
+	"glioma__cube_patient_casedef_rx",
+	"glioma__cube_patient_casedef_rx_variable",
+	"glioma__cube_patient_casedef_proc",
+	"glioma__cube_patient_casedef_lab",
+	"glioma__cube_patient_sample_casedef",
+	"glioma__cube_note_sample_casedef",
+	"glioma__cube_patient_sample_casedef_peri_post",
+	"glioma__cube_note_sample_casedef_peri_post",
+
+    # LLM Variables
+    "glioma__cube_patient_llm_dx",
+    "glioma__cube_patient_llm_surgery",
+    "glioma__cube_patient_llm_drug",
+    "glioma__cube_patient_llm_variant",
+    "glioma__cube_patient_llm_gene",
+]
+
+meta_list = [
+    "glioma__meta_date",
+    "glioma__meta_version",
+]

--- a/cumulus_library_glioma/manifest_llm_CLAUDE.toml
+++ b/cumulus_library_glioma/manifest_llm_CLAUDE.toml
@@ -97,7 +97,7 @@ study_prefix = "glioma"
 ##  https://github.com/smart-on-fhir/cumulus-library/issues/437
 
 "samples for LLM tasks" = [
-    "athena/glioma__sample_casedef_task_CHOP.sql"
+    "athena/glioma__sample_casedef_task_CLAUDE.sql"
 ]
 
 "samples for LLM tasks diagnosis, drug, gene, surgery, progression" = [
@@ -109,14 +109,14 @@ study_prefix = "glioma"
 ]
 
 "glioma LLM (ICDO: grade, topography, morphology, behavior)" = [
-    "athena/glioma__llm_dx_CHOP.sql",
+    "athena/glioma__llm_dx_CLAUDE.sql",
 ]
 
 "glioma LLM (surgery, drug, gene, variant)" = [
-    "athena/glioma__llm_surgery_CHOP.sql",
-    "athena/glioma__llm_drug_CHOP.sql",
-    "athena/glioma__llm_gene_CHOP.sql",
-    "athena/glioma__llm_variant_CHOP.sql",
+    "athena/glioma__llm_surgery_CLAUDE.sql",
+    "athena/glioma__llm_drug_CLAUDE.sql",
+    "athena/glioma__llm_gene_CLAUDE.sql",
+    "athena/glioma__llm_variant_CLAUDE.sql",
 ]
 
 "cube LLM"= [


### PR DESCRIPTION
This PR adds a new manifest version and a variety of specific athena queries that change the target table of interest from `glioma__nlp_gene_gpt_oss_120b` to `glioma__nlp_document_type_claude_sonnet45`, so that other sites using different LLMs can actually build the relevant task tables. 

Noting that this change is just duct-tape in service of the impending demo/CHOP's desire to run things locally. A more robust version of these tables would leverage builders [like we do in IRAE land](https://github.com/smart-on-fhir/cumulus-library-kidney-transplant/blob/433787d40c36a3376d812fedec3300540e0f9e39/cumulus_library_kidney_transplant/nlp_result_to_highlights/irae__highlights_donor.sql.jinja) so that we can check what tables exist dynamically in a site's Athena instance before running SQL that leverages tables that don't exist. 